### PR TITLE
chore: make an object store config optional

### DIFF
--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
     workerServiceGrpcPort: {{ .Values.workerServiceGrpcPort }}
     internalGrpcPort: {{ .Values.internalGrpcPort }}
     enableFileUpload: {{ .Values.enableFileUpload }}
+    {{- if .Values.global.objectStore.s3.bucket }}
     objectStore:
       s3:
         endpointUrl: {{ .Values.global.objectStore.s3.endpointUrl }}
@@ -24,6 +25,7 @@ data:
           externalId: {{ .externalId }}
         {{- end }}
         {{- end }}
+    {{- end }}
     database:
       host: {{ .Values.global.database.host }}
       port: {{ .Values.global.database.port }}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -87,8 +87,8 @@ type Config struct {
 	InternalGRPCPort      int  `yaml:"internalGrpcPort"`
 	EnableFileUpload      bool `yaml:"enableFileUpload"`
 
-	Database    db.Config         `yaml:"database"`
-	ObjectStore ObjectStoreConfig `yaml:"objectStore"`
+	Database    db.Config          `yaml:"database"`
+	ObjectStore *ObjectStoreConfig `yaml:"objectStore"`
 
 	AuthConfig  AuthConfig    `yaml:"auth"`
 	UsageSender sender.Config `yaml:"usageSender"`
@@ -116,8 +116,15 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("sqlite path must be set")
 		}
 	} else {
-		if err := c.ObjectStore.Validate(); err != nil {
-			return fmt.Errorf("object store: %s", err)
+		if c.EnableFileUpload {
+			if c.ObjectStore == nil {
+				return fmt.Errorf("objectStore must be set when file upload is enabled")
+			}
+			if err := c.ObjectStore.Validate(); err != nil {
+				return fmt.Errorf("object store: %s", err)
+			}
+		} else if c.ObjectStore != nil {
+			return fmt.Errorf("objectStore must not be set when file upload is disabled")
 		}
 
 		if err := c.Database.Validate(); err != nil {


### PR DESCRIPTION
Allow end users to skip an object store config if they disable file upload.