### PR TITLE
feat: make CreateFileFromObjectPathRequest reject a non-full path

### DIFF
--- a/api/v1/file_manager_service.pb.go
+++ b/api/v1/file_manager_service.pb.go
@@ -34,6 +34,9 @@ type File struct {
 	Purpose   string `protobuf:"bytes,6,opt,name=purpose,proto3" json:"purpose,omitempty"`
 	// object_store_path is the path to the object in the object storage. This is not in the OpenAI API spec,
 	// but it is convenient for end users especiallly when they create a file with the CreateFileFromObjectPath RPC call.
+	//
+	// If the path starts with "s3://", it is the full path including the bucket name.
+	// Otherwise, path is the relative path to the bucket that is configured with job-manager-dispatcher.
 	ObjectStorePath string `protobuf:"bytes,7,opt,name=object_store_path,json=objectStorePath,proto3" json:"object_store_path,omitempty"`
 }
 
@@ -428,7 +431,7 @@ type CreateFileFromObjectPathRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The object path is the path to the object in the object storage.
+	// The object path is the path to the object in the object storage. The path must start from "s3://".
 	ObjectPath string `protobuf:"bytes,1,opt,name=object_path,json=objectPath,proto3" json:"object_path,omitempty"`
 	Purpose    string `protobuf:"bytes,2,opt,name=purpose,proto3" json:"purpose,omitempty"`
 }
@@ -531,6 +534,8 @@ type GetFilePathResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// Path to the file in the object storage. If the path starts with "s3://", it is the full path including the bucket name.
+	// Otherwise, path is the relative path to the bucket that is configured with job-manager-dispatcher.
 	Path     string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	Filename string `protobuf:"bytes,2,opt,name=filename,proto3" json:"filename,omitempty"`
 }

--- a/api/v1/file_manager_service.proto
+++ b/api/v1/file_manager_service.proto
@@ -22,6 +22,9 @@ message File {
 
   // object_store_path is the path to the object in the object storage. This is not in the OpenAI API spec,
   // but it is convenient for end users especiallly when they create a file with the CreateFileFromObjectPath RPC call.
+  //
+  // If the path starts with "s3://", it is the full path including the bucket name.
+  // Otherwise, path is the relative path to the bucket that is configured with job-manager-dispatcher.
   string object_store_path = 7;
 }
 
@@ -63,7 +66,7 @@ message DeleteFileResponse {
 }
 
 message CreateFileFromObjectPathRequest {
-  // The object path is the path to the object in the object storage.
+  // The object path is the path to the object in the object storage. The path must start from "s3://".
   string object_path = 1;
   string purpose = 2;
 }
@@ -106,6 +109,8 @@ message GetFilePathRequest {
 }
 
 message GetFilePathResponse {
+  // Path to the file in the object storage. If the path starts with "s3://", it is the full path including the bucket name.
+  // Otherwise, path is the relative path to the bucket that is configured with job-manager-dispatcher.
   string path = 1;
   string filename = 2;
 }

--- a/api/v1/file_manager_service.swagger.json
+++ b/api/v1/file_manager_service.swagger.json
@@ -200,7 +200,7 @@
       "properties": {
         "objectPath": {
           "type": "string",
-          "description": "The object path is the path to the object in the object storage."
+          "description": "The object path is the path to the object in the object storage. The path must start from \"s3://\"."
         },
         "purpose": {
           "type": "string"
@@ -246,7 +246,7 @@
         },
         "objectStorePath": {
           "type": "string",
-          "description": "object_store_path is the path to the object in the object storage. This is not in the OpenAI API spec,\nbut it is convenient for end users especiallly when they create a file with the CreateFileFromObjectPath RPC call."
+          "description": "object_store_path is the path to the object in the object storage. This is not in the OpenAI API spec,\nbut it is convenient for end users especiallly when they create a file with the CreateFileFromObjectPath RPC call.\n\nIf the path starts with \"s3://\", it is the full path including the bucket name.\nOtherwise, path is the relative path to the bucket that is configured with job-manager-dispatcher."
         }
       }
     },
@@ -254,7 +254,8 @@
       "type": "object",
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the file in the object storage. If the path starts with \"s3://\", it is the full path including the bucket name.\nOtherwise, path is the relative path to the bucket that is configured with job-manager-dispatcher."
         },
         "filename": {
           "type": "string"

--- a/server/internal/server/files.go
+++ b/server/internal/server/files.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	auv1 "github.com/llmariner/api-usage/api/v1"
@@ -274,6 +275,10 @@ func (s *S) CreateFileFromObjectPath(
 
 	if req.ObjectPath == "" {
 		return nil, status.Error(codes.InvalidArgument, "object_path is required")
+	}
+
+	if !strings.HasPrefix(req.ObjectPath, "s3://") {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid object path: %q. must start with 's3://'", req.ObjectPath)
 	}
 
 	if err := validatePurpose(req.Purpose); err != nil {

--- a/server/internal/server/files_test.go
+++ b/server/internal/server/files_test.go
@@ -221,7 +221,7 @@ func TestCreateFileFromObjectPath(t *testing.T) {
 
 	// Test successful creation
 	resp, err := srv.CreateFileFromObjectPath(ctx, &v1.CreateFileFromObjectPathRequest{
-		ObjectPath: "path/to/test-file.jsonl",
+		ObjectPath: "s3://bucket/path/to/test-file.jsonl",
 		Purpose:    purposeFineTune,
 	})
 	assert.NoError(t, err)
@@ -233,7 +233,7 @@ func TestCreateFileFromObjectPath(t *testing.T) {
 	// Verify the file exists in the store
 	f, err := st.GetFile(resp.Id, defaultProjectID)
 	assert.NoError(t, err)
-	assert.Equal(t, "path/to/test-file.jsonl", f.ObjectStorePath)
+	assert.Equal(t, "s3://bucket/path/to/test-file.jsonl", f.ObjectStorePath)
 
 	// Test missing object path
 	_, err = srv.CreateFileFromObjectPath(ctx, &v1.CreateFileFromObjectPathRequest{


### PR DESCRIPTION
Reject a request if the path does not start with "s3://".